### PR TITLE
collect testthat.Rout.fail logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ runs:
         else
           echo "No binary package $BINARYPKG found. Skipping deployment."
         fi
-        find . -regex '.*\.R*out' | while read f; do echo "::group::$f"; echo " ===== $f ====="; tail -n1000 $f; echo "::endgroup::"; done
+        find . -regextype posix-extended -regex '.*\.R*out(\.fail)?' | while read f; do echo "::group::$f"; echo " ===== $f ====="; tail -n1000 $f; echo "::endgroup::"; done


### PR DESCRIPTION
The checks were not collecting the testthat.Rout.fail logs. I updated the find command to include these and also used posix-extended regex because I'm not terribly comfortable with the limitations of emacs regex (the default for find). 