### PR TITLE
Revert "collect testthat.Rout.fail logs"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ runs:
         else
           echo "No binary package $BINARYPKG found. Skipping deployment."
         fi
-        find . -regextype posix-extended -regex '.*\.R*out(\.fail)?' | while read f; do echo "::group::$f"; echo " ===== $f ====="; tail -n1000 $f; echo "::endgroup::"; done
+        find . -regex '.*\.R*out' | while read f; do echo "::group::$f"; echo " ===== $f ====="; tail -n1000 $f; echo "::endgroup::"; done


### PR DESCRIPTION
Reverts r-universe-org/post-check#3

Does not work on MacOS, all checks now fail with `find: -regextype: unknown primary or operator`